### PR TITLE
Fix: Fixed API logic to use user accessible endpoints.

### DIFF
--- a/src/components/Authentication/Authentication.js
+++ b/src/components/Authentication/Authentication.js
@@ -5,10 +5,8 @@ import Container from "react-bootstrap/Container";
 import Row from "react-bootstrap/Row";
 import {Button, Card, Col} from "react-bootstrap";
 
-import SecComCarousel from "../SecComCarousel/SecComCarousel";
 import {useKeycloak} from "@react-keycloak/web";
 import DropdownCardItem from "../DropdownCardItem/DropdownCardItem";
-import {BsCameraVideoFill} from "react-icons/bs";
 
 const Authentication = () => {
 

--- a/src/components/IntrusionCard/IntrusionCard.js
+++ b/src/components/IntrusionCard/IntrusionCard.js
@@ -74,8 +74,6 @@ const IntrusionCard = (props) => {
 IntrusionCard.propTypes = {
     /** Intrusion details to be displayed on the card */
     intrusion: PropTypes.object,
-    /** Function to be called when the View Video button is clicked */
-    handleSelection: PropTypes.func
 };
 
 IntrusionCard.defaultProps = {
@@ -84,8 +82,7 @@ IntrusionCard.defaultProps = {
         propertyID: "",
         cameraID: "",
         intrusionDate: ""
-    },
-    handleSelection: () => {}
+    }
 };
 
 export default IntrusionCard;

--- a/src/pages/DashboardPage.js
+++ b/src/pages/DashboardPage.js
@@ -28,9 +28,7 @@ const DashboardPage = () => {
 
         getProperties()
             .then(r => setProperties(r.data))
-            .catch(() => {
-                toast.error("Unable to get your properties.")
-            });
+            .catch(() => toast.error("Unable to get your properties."));
 
     }, []);
 
@@ -46,22 +44,18 @@ const DashboardPage = () => {
             alarmsIds.forEach(alarmId => {
                 getAlarm(alarmId)
                     .then(r => setAlarms([...alarms, r.data]))
-                    .catch(() => {
-                        toast.error("Unable to get data for alarm")
-                    });
+                    .catch(() => toast.error(`Unable to get data for alarm ${alarmId}`));
             });
 
             camerasIds.forEach(cameraId => {
                getCamera(cameraId)
                    .then(r => setCameras([...cameras, r.data]))
-                   .catch(() => toast.error("Unable to get data for camera"))
+                   .catch(() => toast.error(`Unable to get data for camera ${cameraId}`));
             });
 
             getIntrusionsFromProperty(property.id)
                 .then(r => setIntrusions(r.data))
-                .catch(() => {
-                    toast.error("Unable to get intrusions for your properties.")
-                });
+                .catch(() => toast.error(`Unable to get intrusions for property ${property.id}`));
 
         }
 

--- a/src/pages/DashboardPage.js
+++ b/src/pages/DashboardPage.js
@@ -6,10 +6,10 @@ import ListCard from "../components/ListCard/ListCard";
 import ChartCard from "../components/ChartCard/ChartCard";
 import DescriptionElement from "../components/ListElements/DescriptionElement/DescriptionElement";
 import {useEffect, useState} from "react";
-import {getAlarms, getCameras, getProperties} from "../utils/SitesManagementApiHandler";
+import {getAlarm, getCamera, getProperties} from "../utils/SitesManagementApiHandler";
 import {toast} from "react-toastify";
 import {propertiesToOverviewComponent} from "../services/PropertiesService";
-import {getIntrusions} from "../utils/IntrusionApiHandler";
+import {getIntrusionsFromProperty} from "../utils/IntrusionApiHandler";
 import {intrusionsToChartData, intrusionsToOverviewComponent} from "../services/IntrusionsService";
 
 const DashboardPage = () => {
@@ -32,25 +32,40 @@ const DashboardPage = () => {
                 toast.error("Unable to get your properties.")
             });
 
-        getAlarms()
-            .then(r => setAlarms(r.data))
-            .catch(() => {
-                toast.error("Unable to get your alarms.")
-            });
-
-        getCameras()
-            .then(r => setCameras(r.data))
-            .catch(() => {
-                toast.error("Unable to get your cameras.")
-            });
-
-        getIntrusions()
-            .then(r => setIntrusions(r.data))
-            .catch(() => {
-                toast.error("Unable to get intrusions for your properties.")
-            });
-
     }, []);
+
+    useEffect(() => {
+
+        if (!properties) return;
+
+        for (let property of properties) {
+
+            let alarmsIds = property.alarms;
+            let camerasIds = property.cameras;
+
+            alarmsIds.forEach(alarmId => {
+                getAlarm(alarmId)
+                    .then(r => setAlarms([...alarms, r.data]))
+                    .catch(() => {
+                        toast.error("Unable to get data for alarm")
+                    });
+            });
+
+            camerasIds.forEach(cameraId => {
+               getCamera(cameraId)
+                   .then(r => setCameras([...cameras, r.data]))
+                   .catch(() => toast.error("Unable to get data for camera"))
+            });
+
+            getIntrusionsFromProperty(property.id)
+                .then(r => setIntrusions(r.data))
+                .catch(() => {
+                    toast.error("Unable to get intrusions for your properties.")
+                });
+
+        }
+
+    }, [properties]);
 
     const onDetailsSelected = (detailsInfo) => {
 

--- a/src/pages/IntrusionsPage.js
+++ b/src/pages/IntrusionsPage.js
@@ -4,25 +4,39 @@ import SearchBar from "../components/SearchBar/SearchBar";
 import {useEffect, useState} from "react";
 import IntrusionCard from "../components/IntrusionCard/IntrusionCard";
 import {Col} from "react-bootstrap";
-import {getIntrusions} from "../utils/IntrusionApiHandler";
+import {getIntrusionsFromProperty} from "../utils/IntrusionApiHandler";
 import {toast} from "react-toastify";
+import {getProperties} from "../utils/SitesManagementApiHandler";
 
 
 const IntrusionsPage = () => {
 
+    const [properties, setProperties] = useState([]);
     const [intrusions, setIntrusions] = useState([]);
     const [filteredIntrusions, setFilteredIntrusions] = useState([]);
 
     useEffect(() => {
 
-        getIntrusions()
-            .then(r => {
-                setIntrusions(r.data);
-                setFilteredIntrusions(r.data);
-            })
-            .catch(() => toast.error("Unable to obtain intrusions data."))
+        getProperties()
+            .then(r => setProperties(r.data))
+            .catch(() => toast.error("Unable to get data for properties"));
 
     }, []);
+
+    useEffect(() => {
+
+        for (let property of properties) {
+
+            getIntrusionsFromProperty(property.id)
+                .then(r => {
+                    setIntrusions([...intrusions, r.data]);
+                    setFilteredIntrusions([...filteredIntrusions, r.data]);
+                })
+                .catch(() => toast.error(`Unable to obtain intrusions data for property ${property.id}`))
+
+        }
+
+    }, [properties]);
 
     const buildIntrusionsPanels = () => {
 

--- a/src/pages/IntrusionsPage.js
+++ b/src/pages/IntrusionsPage.js
@@ -48,7 +48,7 @@ const IntrusionsPage = () => {
             const intrusion = filteredIntrusionsSorted[idx];
             intrusionsPanels.push(
                 <Col className="my-2 col-3" key={intrusion.key}>
-                    <IntrusionCard intrusion={intrusion} handleSelection={() => {}}/>
+                    <IntrusionCard intrusion={intrusion}/>
                 </Col>
             );
         }


### PR DESCRIPTION
### Description

The Client Panel was using endpoints reserved for administrators to get information about the user's properties. This caused a 403 error in most of the endpoint calls. This PR fixes this issue by replacing all the admin endpoints with endpoints that are available to the client.

### What changed?

* Replaced getAllAlarms() calls for getAlarm(alarmId) call.
* Replaced getAllCameras() calls for getCamera(cameraId) call.
* Replaced getIntrusions() calls for getIntrusionForPorperty(propertyId) call.

### How was it tested?

Using regression testing.

### Documentation

https://documentation-ua-es-22-23.vercel.app/